### PR TITLE
feat: add content collection schemas for blog and projects (closes #6)

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,28 @@
+import { defineCollection, z } from "astro:content";
+import { glob } from "astro/loaders";
+
+const blog = defineCollection({
+  loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/blog" }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    date: z.coerce.date(),
+    updatedDate: z.coerce.date().optional(),
+    tags: z.array(z.string()).default([]),
+    draft: z.boolean().default(false),
+  }),
+});
+
+const projects = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/projects" }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    tags: z.array(z.string()).default([]),
+    repoUrl: z.string().url().optional(),
+    demoUrl: z.string().url().optional(),
+    sortOrder: z.number().default(0),
+  }),
+});
+
+export const collections = { blog, projects };

--- a/src/content/blog/hello-world.md
+++ b/src/content/blog/hello-world.md
@@ -1,0 +1,8 @@
+---
+title: "Hello World"
+description: "First post on the new site."
+date: 2026-02-24
+tags: ["meta"]
+---
+
+This is a test post to verify the content collection is working.

--- a/src/content/projects/clauson.md
+++ b/src/content/projects/clauson.md
@@ -1,0 +1,9 @@
+---
+title: "clauson"
+description: "A CLI for analyzing Claude Code's JSONL session logs."
+tags: ["rust", "cli", "ai"]
+repoUrl: "https://github.com/anhadg/clauson"
+sortOrder: 1
+---
+
+A Rust CLI that parses Claude Code session logs and provides analytics on token usage, tool calls, timing, and conversation structure. Think of it as htop for Claude Code sessions.


### PR DESCRIPTION
## Summary
- Content collection config at `src/content.config.ts` using Astro v5 content layer API
- Blog schema: title, description, date, updatedDate, tags, draft
- Projects schema: title, description, tags, repoUrl, demoUrl, sortOrder
- Test blog post (`hello-world.md`) and test project (`clauson.md`)

Closes #6