### PR TITLE
feat: add base layout with header navigation and footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,9 @@
+---
+const year = new Date().getFullYear();
+---
+
+<footer class="border-t border-stone-200 mt-16">
+  <div class="max-w-4xl mx-auto px-4 py-8 text-sm text-stone-500">
+    <p>&copy; {year} Anhad Jai Singh</p>
+  </div>
+</footer>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,0 +1,35 @@
+---
+const navLinks = [
+  { href: "/", label: "Home" },
+  { href: "/blog", label: "Blog" },
+  { href: "/projects", label: "Projects" },
+  { href: "/about", label: "About" },
+  { href: "/links", label: "Links" },
+  { href: "/contact", label: "Contact" },
+];
+
+const currentPath = Astro.url.pathname;
+---
+
+<header class="sticky top-0 z-50 bg-stone-50/80 backdrop-blur-sm border-b border-stone-200">
+  <nav class="max-w-4xl mx-auto px-4 py-4 flex items-center justify-between">
+    <a href="/" class="font-serif text-xl font-bold text-stone-900 hover:text-accent transition-colors">
+      ffledgling
+    </a>
+    <ul class="flex gap-6 text-sm">
+      {navLinks.map((link) => (
+        <li>
+          <a
+            href={link.href}
+            class:list={[
+              "transition-colors hover:text-accent",
+              currentPath === link.href ? "text-accent font-medium" : "text-stone-600",
+            ]}
+          >
+            {link.label}
+          </a>
+        </li>
+      ))}
+    </ul>
+  </nav>
+</header>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,0 +1,30 @@
+---
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
+import "../styles/global.css";
+
+interface Props {
+  title: string;
+  description?: string;
+}
+
+const { title, description = "Personal website of Anhad Jai Singh" } = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content={description} />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <title>{title} | ffledgling.dev</title>
+  </head>
+  <body class="bg-stone-50 text-stone-900 font-sans antialiased">
+    <Header />
+    <main class="max-w-4xl mx-auto px-4 py-8">
+      <slot />
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,14 +1,13 @@
 ---
-import "../styles/global.css";
+import BaseLayout from "../layouts/BaseLayout.astro";
 ---
 
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
-    <title>ffledgling.dev</title>
-  </head>
-  <body class="bg-stone-50 text-stone-900">
-    <h1 class="text-3xl font-bold p-8">ffledgling.dev — coming soon</h1>
-  </body>
-</html>
+<BaseLayout title="Home">
+  <h1 class="font-serif text-4xl font-bold mb-2">Anhad Jai Singh</h1>
+  <p class="text-lg text-stone-500 mb-8">Software developer. Curious about everything.</p>
+  <p class="text-stone-700 max-w-prose leading-relaxed">
+    Welcome to my corner of the internet. I write about software, and occasionally about
+    the many other things that catch my attention — finance, golf, mechanical keyboards,
+    watches, art, and whatever else I'm exploring.
+  </p>
+</BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,1 +1,11 @@
 @import "tailwindcss";
+
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:ital,wght@0,400;0,700;1,400&family=JetBrains+Mono:wght@400;500&display=swap');
+
+@theme {
+  --font-sans: "Inter", sans-serif;
+  --font-serif: "Playfair Display", serif;
+  --font-mono: "JetBrains Mono", monospace;
+  --color-accent: #2563eb;
+  --color-accent-hover: #1d4ed8;
+}


### PR DESCRIPTION
## Summary
- BaseLayout with head meta, header, main slot, footer
- Sticky header nav with site name and page links
- Footer with copyright
- Google Fonts: Inter (body), Playfair Display (headings), JetBrains Mono (code)
- Theme CSS custom properties for fonts and accent color
- Index page updated to use BaseLayout

Closes #5

## Test plan
- [x] `npm run build` passes successfully
- [ ] Verify header renders with all nav links
- [ ] Verify footer renders with copyright year
- [ ] Verify fonts load from Google Fonts
- [ ] Verify active nav link highlighting works

🤖 Generated with [Claude Code](https://claude.com/claude-code)