### PR TITLE
feat: add About, Projects, Links, and Contact pages (closes #8)

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,0 +1,20 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+---
+
+<BaseLayout title="About">
+  <div class="max-w-prose mx-auto">
+    <h1 class="font-serif text-4xl font-bold mb-8">About</h1>
+    <div class="prose prose-stone prose-lg">
+      <p>
+        I'm Anhad Jai Singh — a software developer by profession with a wide
+        range of interests spanning finance, economics, golf, mechanical
+        keyboards, watches, art, fashion, and more.
+      </p>
+      <p>
+        Placeholder for more detailed about content. Link to
+        <a href="/resume.pdf">downloadable resume (PDF)</a>.
+      </p>
+    </div>
+  </div>
+</BaseLayout>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,0 +1,21 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+---
+
+<BaseLayout title="Contact">
+  <div class="max-w-prose mx-auto">
+    <h1 class="font-serif text-4xl font-bold mb-8">Get in Touch</h1>
+    <div class="prose prose-stone prose-lg">
+      <p>
+        The best way to reach me is via email at
+        <a href="mailto:ffledgling@gmail.com">ffledgling@gmail.com</a>.
+      </p>
+      <p>
+        You can also find me on <a href="https://github.com/ffledgling"
+          >GitHub</a
+        >
+        and <a href="https://linkedin.com/in/anhadjaisingh">LinkedIn</a>.
+      </p>
+    </div>
+  </div>
+</BaseLayout>

--- a/src/pages/links.astro
+++ b/src/pages/links.astro
@@ -1,0 +1,44 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+
+const links = [
+  {
+    name: "GitHub",
+    url: "https://github.com/ffledgling",
+    handle: "@ffledgling",
+  },
+  {
+    name: "LinkedIn",
+    url: "https://linkedin.com/in/anhadjaisingh",
+    handle: "Anhad Jai Singh",
+  },
+  {
+    name: "X / Twitter",
+    url: "https://x.com/ffledgling",
+    handle: "@ffledgling",
+  },
+];
+---
+
+<BaseLayout title="Links">
+  <div class="max-w-prose mx-auto">
+    <h1 class="font-serif text-4xl font-bold mb-8">Links</h1>
+    <ul class="space-y-4">
+      {
+        links.map((link) => (
+          <li>
+            <a
+              href={link.url}
+              class="flex items-center justify-between p-4 border border-stone-200 rounded-lg hover:border-stone-300 transition-colors"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span class="font-medium">{link.name}</span>
+              <span class="text-stone-500 text-sm">{link.handle}</span>
+            </a>
+          </li>
+        ))
+      }
+    </ul>
+  </div>
+</BaseLayout>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,0 +1,47 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import { getCollection } from "astro:content";
+
+const projects = (await getCollection("projects")).sort(
+  (a, b) => a.data.sortOrder - b.data.sortOrder,
+);
+---
+
+<BaseLayout title="Projects">
+  <h1 class="font-serif text-4xl font-bold mb-8">Projects</h1>
+  <div class="grid gap-6 sm:grid-cols-2">
+    {
+      projects.map((project) => (
+        <div class="border border-stone-200 rounded-lg p-6 hover:border-stone-300 transition-colors">
+          <h2 class="text-lg font-semibold mb-1">{project.data.title}</h2>
+          <p class="text-stone-600 text-sm mb-3">{project.data.description}</p>
+          <div class="flex flex-wrap gap-2 mb-3">
+            {project.data.tags.map((tag: string) => (
+              <span class="text-xs bg-stone-100 text-stone-600 px-2 py-0.5 rounded">
+                {tag}
+              </span>
+            ))}
+          </div>
+          <div class="flex gap-3 text-sm">
+            {project.data.repoUrl && (
+              <a
+                href={project.data.repoUrl}
+                class="text-accent hover:underline"
+              >
+                Source
+              </a>
+            )}
+            {project.data.demoUrl && (
+              <a
+                href={project.data.demoUrl}
+                class="text-accent hover:underline"
+              >
+                Demo
+              </a>
+            )}
+          </div>
+        </div>
+      ))
+    }
+  </div>
+</BaseLayout>

--- a/tests/e2e/pages.spec.ts
+++ b/tests/e2e/pages.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "@playwright/test";
+
+const pages = [
+  { path: "/", title: "Home" },
+  { path: "/about", title: "About" },
+  { path: "/projects", title: "Projects" },
+  { path: "/links", title: "Links" },
+  { path: "/contact", title: "Contact" },
+];
+
+for (const { path, title } of pages) {
+  test(`${title} page loads at ${path}`, async ({ page }) => {
+    await page.goto(path);
+    await expect(page).toHaveTitle(new RegExp(title, "i"));
+  });
+}


### PR DESCRIPTION
## Summary
- About page with bio and resume placeholder
- Projects page with card grid from content collection
- Links page with social profiles
- Contact page with email and social links
- E2E tests for all pages

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)