### PR TITLE
feat: add dark mode with theme toggle (closes #10)

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,8 +2,8 @@
 const year = new Date().getFullYear();
 ---
 
-<footer class="border-t border-stone-200 mt-16">
-  <div class="max-w-4xl mx-auto px-4 py-8 text-sm text-stone-500">
+<footer class="border-t border-stone-200 dark:border-stone-700 mt-16">
+  <div class="max-w-4xl mx-auto px-4 py-8 text-sm text-stone-500 dark:text-stone-400">
     <p>&copy; {year} Anhad Jai Singh</p>
   </div>
 </footer>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,4 +1,6 @@
 ---
+import ThemeToggle from "./ThemeToggle.astro";
+
 const navLinks = [
   { href: "/", label: "Home" },
   { href: "/blog", label: "Blog" },
@@ -12,12 +14,12 @@ const currentPath = Astro.url.pathname;
 ---
 
 <header
-  class="sticky top-0 z-50 bg-stone-50/80 backdrop-blur-sm border-b border-stone-200"
+  class="sticky top-0 z-50 bg-stone-50/80 dark:bg-stone-900/80 backdrop-blur-sm border-b border-stone-200 dark:border-stone-700"
 >
   <nav class="max-w-4xl mx-auto px-4 py-4 flex items-center justify-between">
     <a
       href="/"
-      class="font-serif text-xl font-bold text-stone-900 hover:text-accent transition-colors"
+      class="font-serif text-xl font-bold text-stone-900 dark:text-stone-100 hover:text-accent dark:hover:text-accent transition-colors"
     >
       ffledgling
     </a>
@@ -31,7 +33,7 @@ const currentPath = Astro.url.pathname;
                 "transition-colors hover:text-accent",
                 currentPath === link.href
                   ? "text-accent font-medium"
-                  : "text-stone-600",
+                  : "text-stone-600 dark:text-stone-400",
               ]}
             >
               {link.label}
@@ -40,5 +42,6 @@ const currentPath = Astro.url.pathname;
         ))
       }
     </ul>
+    <ThemeToggle />
   </nav>
 </header>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,0 +1,27 @@
+<button
+  id="theme-toggle"
+  aria-label="Toggle dark mode"
+  class="text-stone-600 hover:text-stone-900 dark:text-stone-400 dark:hover:text-stone-100 transition-colors"
+>
+  <span id="theme-icon-light" class="hidden dark:inline">&#9788;</span>
+  <span id="theme-icon-dark" class="inline dark:hidden">&#9790;</span>
+</button>
+
+<script>
+  function initTheme() {
+    const toggle = document.getElementById("theme-toggle");
+    const saved = localStorage.getItem("theme");
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+
+    if (saved === "dark" || (!saved && prefersDark)) {
+      document.documentElement.classList.add("dark");
+    }
+
+    toggle?.addEventListener("click", () => {
+      const isDark = document.documentElement.classList.toggle("dark");
+      localStorage.setItem("theme", isDark ? "dark" : "light");
+    });
+  }
+  initTheme();
+  document.addEventListener("astro:after-swap", initTheme);
+</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -21,7 +21,7 @@ const { title, description = "Personal website of Anhad Jai Singh" } =
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>{title} | ffledgling.dev</title>
   </head>
-  <body class="bg-stone-50 text-stone-900 font-sans antialiased">
+  <body class="bg-stone-50 dark:bg-stone-900 text-stone-900 dark:text-stone-100 font-sans antialiased transition-colors">
     <Header />
     <main class="max-w-4xl mx-auto px-4 py-8">
       <slot />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,3 +9,5 @@
   --color-accent: #2563eb;
   --color-accent-hover: #1d4ed8;
 }
+
+@custom-variant dark (&:where(.dark, .dark *));


### PR DESCRIPTION
## Summary
- ThemeToggle component with sun/moon icons
- Dark mode via .dark class on html element
- Persists preference in localStorage, respects system default
- All components updated with dark: Tailwind variants
- @custom-variant dark configured in global CSS

Closes #10