### PR TITLE
feat: add blog listing and post pages (closes #7)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ffledgling-dev",
       "version": "0.0.1",
       "dependencies": {
+        "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.2.1",
         "astro": "^5.0.0",
         "tailwindcss": "^4.2.1"
@@ -2256,6 +2257,31 @@
       ],
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@tailwindcss/vite": {
@@ -8177,7 +8203,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vfile": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     ]
   },
   "dependencies": {
+    "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.1",
     "astro": "^5.0.0",
     "tailwindcss": "^4.2.1"

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -1,0 +1,34 @@
+---
+import BaseLayout from "./BaseLayout.astro";
+import { formatDate } from "../lib/utils";
+
+interface Props {
+  title: string;
+  description: string;
+  date: Date;
+  tags: string[];
+}
+
+const { title, description, date, tags } = Astro.props;
+---
+
+<BaseLayout title={title} description={description}>
+  <article class="max-w-prose mx-auto">
+    <header class="mb-8">
+      <h1 class="font-serif text-4xl font-bold mb-3">{title}</h1>
+      <div class="flex flex-wrap gap-x-4 gap-y-1 text-sm text-stone-500">
+        <time datetime={date.toISOString()}>{formatDate(date)}</time>
+        {tags.length > 0 && (
+          <div class="flex gap-2">
+            {tags.map((tag) => (
+              <span class="text-accent">#{tag}</span>
+            ))}
+          </div>
+        )}
+      </div>
+    </header>
+    <div class="prose prose-stone prose-lg max-w-none">
+      <slot />
+    </div>
+  </article>
+</BaseLayout>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,12 @@
+export function formatDate(date: Date): string {
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+export function estimateReadingTime(content: string): number {
+  const words = content.split(/\s+/).length;
+  return Math.ceil(words / 200);
+}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,0 +1,24 @@
+---
+import { getCollection, render } from "astro:content";
+import BlogPostLayout from "../../layouts/BlogPostLayout.astro";
+
+export async function getStaticPaths() {
+  const posts = await getCollection("blog");
+  return posts.map((post) => ({
+    params: { slug: post.id },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+---
+
+<BlogPostLayout
+  title={post.data.title}
+  description={post.data.description}
+  date={post.data.date}
+  tags={post.data.tags}
+>
+  <Content />
+</BlogPostLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,37 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { getCollection } from "astro:content";
+import { formatDate } from "../../lib/utils";
+
+const posts = (await getCollection("blog"))
+  .filter((post) => !post.data.draft)
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+---
+
+<BaseLayout title="Blog">
+  <h1 class="font-serif text-4xl font-bold mb-8">Blog</h1>
+  <ul class="space-y-8">
+    {posts.map((post) => (
+      <li>
+        <a href={`/blog/${post.id}`} class="group block">
+          <h2 class="text-xl font-semibold group-hover:text-accent transition-colors">
+            {post.data.title}
+          </h2>
+          <div class="flex flex-wrap gap-x-4 gap-y-1 text-sm text-stone-500 mt-1">
+            <time datetime={post.data.date.toISOString()}>
+              {formatDate(post.data.date)}
+            </time>
+            {post.data.tags.length > 0 && (
+              <div class="flex gap-2">
+                {post.data.tags.map((tag: string) => (
+                  <span>#{tag}</span>
+                ))}
+              </div>
+            )}
+          </div>
+          <p class="text-stone-600 mt-2">{post.data.description}</p>
+        </a>
+      </li>
+    ))}
+  </ul>
+</BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@plugin "@tailwindcss/typography";
 
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:ital,wght@0,400;0,700;1,400&family=JetBrains+Mono:wght@400;500&display=swap");
 
@@ -9,3 +10,5 @@
   --color-accent: #2563eb;
   --color-accent-hover: #1d4ed8;
 }
+
+@custom-variant dark (&:where(.dark, .dark *));

--- a/tests/e2e/blog.spec.ts
+++ b/tests/e2e/blog.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from "@playwright/test";
+
+test("blog listing page loads", async ({ page }) => {
+  await page.goto("/blog");
+  await expect(page.locator("h1")).toContainText("Blog");
+});
+
+test("blog listing shows posts", async ({ page }) => {
+  await page.goto("/blog");
+  const posts = page.locator("ul li");
+  await expect(posts).not.toHaveCount(0);
+});
+
+test("blog post page loads", async ({ page }) => {
+  await page.goto("/blog/hello-world");
+  await expect(page.locator("h1")).toContainText("Hello World");
+});

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { formatDate, estimateReadingTime } from "../../src/lib/utils";
+
+describe("formatDate", () => {
+  it("formats a date in US English", () => {
+    const date = new Date("2026-02-24");
+    const result = formatDate(date);
+    expect(result).toContain("2026");
+    expect(result).toContain("February");
+    expect(result).toContain("24");
+  });
+});
+
+describe("estimateReadingTime", () => {
+  it("estimates reading time based on 200 wpm", () => {
+    const words = Array(400).fill("word").join(" ");
+    expect(estimateReadingTime(words)).toBe(2);
+  });
+
+  it("rounds up partial minutes", () => {
+    const words = Array(250).fill("word").join(" ");
+    expect(estimateReadingTime(words)).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Blog listing page at `/blog` with posts sorted newest-first
- Individual blog post pages at `/blog/[slug]` using content collections
- `BlogPostLayout` with metadata header and prose styling
- Utility functions (`formatDate`, `estimateReadingTime`) with unit tests
- Tailwind typography plugin for prose content
- E2E tests for blog listing and post pages

Closes #7