### PR TITLE
feat: add recent posts to homepage (closes #9)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,15 +1,53 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { getCollection } from "astro:content";
+import { formatDate } from "../lib/utils";
+
+const recentPosts = (await getCollection("blog"))
+  .filter((post) => !post.data.draft)
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
+  .slice(0, 5);
 ---
 
 <BaseLayout title="Home">
-  <h1 class="font-serif text-4xl font-bold mb-2">Anhad Jai Singh</h1>
-  <p class="text-lg text-stone-500 mb-8">
-    Software developer. Curious about everything.
-  </p>
-  <p class="text-stone-700 max-w-prose leading-relaxed">
-    Welcome to my corner of the internet. I write about software, and
-    occasionally about the many other things that catch my attention — finance,
-    golf, mechanical keyboards, watches, art, and whatever else I'm exploring.
-  </p>
+  <section class="mb-16">
+    <h1 class="font-serif text-4xl font-bold mb-2">Anhad Jai Singh</h1>
+    <p class="text-lg text-stone-500 dark:text-stone-400 mb-8">
+      Software developer. Curious about everything.
+    </p>
+    <p class="text-stone-700 dark:text-stone-300 max-w-prose leading-relaxed">
+      Welcome to my corner of the internet. I write about software, and
+      occasionally about the many other things that catch my attention —
+      finance, golf, mechanical keyboards, watches, art, and whatever else I'm
+      exploring.
+    </p>
+  </section>
+
+  <section>
+    <h2 class="font-serif text-2xl font-bold mb-6">Recent Writing</h2>
+    <ul class="space-y-6">
+      {
+        recentPosts.map((post) => (
+          <li>
+            <a href={`/blog/${post.id}`} class="group block">
+              <h3 class="text-lg font-semibold group-hover:text-accent transition-colors">
+                {post.data.title}
+              </h3>
+              <div class="text-sm text-stone-500 dark:text-stone-400 mt-1">
+                <time datetime={post.data.date.toISOString()}>
+                  {formatDate(post.data.date)}
+                </time>
+              </div>
+            </a>
+          </li>
+        ))
+      }
+    </ul>
+    <a
+      href="/blog"
+      class="inline-block mt-6 text-accent hover:underline text-sm"
+    >
+      View all posts &rarr;
+    </a>
+  </section>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- Homepage now shows an intro section and the latest 5 blog posts under "Recent Writing"
- Dark mode variants included for text colors
- Links to individual blog posts and a "View all posts" link to the blog index

Closes #9