### PR TITLE
feat: add responsive mobile navigation (closes #11)

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -23,7 +23,9 @@ const currentPath = Astro.url.pathname;
     >
       ffledgling
     </a>
-    <ul class="flex gap-6 text-sm">
+
+    <!-- Desktop navigation -->
+    <ul class="hidden md:flex gap-6 text-sm">
       {
         navLinks.map((link) => (
           <li>
@@ -42,6 +44,100 @@ const currentPath = Astro.url.pathname;
         ))
       }
     </ul>
-    <ThemeToggle />
+
+    <!-- Desktop theme toggle -->
+    <div class="hidden md:block">
+      <ThemeToggle />
+    </div>
+
+    <!-- Mobile controls -->
+    <div class="flex md:hidden items-center gap-3">
+      <ThemeToggle />
+      <button
+        id="mobile-menu-toggle"
+        aria-label="Toggle menu"
+        aria-expanded="false"
+        class="text-stone-600 hover:text-stone-900 dark:text-stone-400 dark:hover:text-stone-100 transition-colors"
+      >
+        <!-- Hamburger icon -->
+        <svg
+          id="hamburger-icon"
+          class="w-6 h-6"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M4 6h16M4 12h16M4 18h16"></path>
+        </svg>
+        <!-- Close (X) icon -->
+        <svg
+          id="close-icon"
+          class="w-6 h-6 hidden"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M6 18L18 6M6 6l12 12"></path>
+        </svg>
+      </button>
+    </div>
   </nav>
+
+  <!-- Mobile dropdown menu -->
+  <div
+    id="mobile-menu"
+    class="hidden md:hidden border-t border-stone-200 dark:border-stone-700 bg-stone-50/95 dark:bg-stone-900/95 backdrop-blur-sm"
+  >
+    <ul class="max-w-4xl mx-auto px-4 py-3 flex flex-col gap-3 text-sm">
+      {
+        navLinks.map((link) => (
+          <li>
+            <a
+              href={link.href}
+              class:list={[
+                "block py-1 transition-colors hover:text-accent",
+                currentPath === link.href
+                  ? "text-accent font-medium"
+                  : "text-stone-600 dark:text-stone-400",
+              ]}
+            >
+              {link.label}
+            </a>
+          </li>
+        ))
+      }
+    </ul>
+  </div>
 </header>
+
+<script>
+  function initMobileMenu() {
+    const toggle = document.getElementById("mobile-menu-toggle");
+    const menu = document.getElementById("mobile-menu");
+    const hamburgerIcon = document.getElementById("hamburger-icon");
+    const closeIcon = document.getElementById("close-icon");
+
+    if (!toggle || !menu || !hamburgerIcon || !closeIcon) return;
+
+    toggle.addEventListener("click", () => {
+      const isOpen = menu.classList.toggle("hidden");
+      // isOpen is true when "hidden" was added (menu closed)
+      toggle.setAttribute("aria-expanded", String(!isOpen));
+      hamburgerIcon.classList.toggle("hidden", !isOpen);
+      closeIcon.classList.toggle("hidden", isOpen);
+    });
+  }
+
+  initMobileMenu();
+  document.addEventListener("astro:after-swap", initMobileMenu);
+</script>

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "@playwright/test";
+
+test("header navigation links are present on desktop", async ({ page }) => {
+  await page.goto("/");
+  const nav = page.locator("header nav");
+  await expect(nav.getByRole("link", { name: "Home" })).toBeVisible();
+  await expect(nav.getByRole("link", { name: "Blog" })).toBeVisible();
+  await expect(nav.getByRole("link", { name: "About" })).toBeVisible();
+});
+
+test("mobile menu toggle works", async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 667 });
+  await page.goto("/");
+  const menuButton = page.getByLabel("Toggle menu");
+  await expect(menuButton).toBeVisible();
+  await menuButton.click();
+  await expect(page.getByRole("link", { name: "Blog" })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- Add hamburger menu button visible on mobile viewports (below `md` breakpoint)
- Dropdown mobile menu with all navigation links
- Toggle between hamburger and X (close) icons with aria-expanded state
- Dark mode support preserved for all new elements
- E2E tests for desktop nav link visibility and mobile menu toggle

## Test plan
- [x] Build passes (`npm run build`)
- [x] All E2E tests pass (11/11), including new navigation tests
- [ ] Verify hamburger icon appears on mobile viewport
- [ ] Verify clicking hamburger opens mobile menu with all nav links
- [ ] Verify clicking X icon closes mobile menu
- [ ] Verify dark mode styling on mobile menu

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)